### PR TITLE
Hotfix/shell escape

### DIFF
--- a/script/run_foels.sh
+++ b/script/run_foels.sh
@@ -212,7 +212,8 @@ else
                      cd "${ROOT_DIR}"
 
                      # Check if input images start from 00000 or 00001 to determine if renaming is needed
-                     # MemFlow's inference_wrapper.py now correctly detects the starting index
+                     # MemFlow's inference_wrapper.py now automatically scans the input directory for image files,
+                     # detects the starting index (e.g., 00000, 000000, or 00001), and generates flow files with the correct indexing.
                      if [ -f "${INPUT_ABS}/00000.jpg" ] || [ -f "${INPUT_ABS}/00000.png" ]; then
                          echo "[INFO] Input images start from 00000, MemFlow generated 0-indexed flow files correctly"
                      elif [ -f "${INPUT_ABS}/000000.jpg" ] || [ -f "${INPUT_ABS}/000000.png" ]; then

--- a/script/run_foels.sh
+++ b/script/run_foels.sh
@@ -359,16 +359,21 @@ if [ "$SKIP_FRAMES" -ge "$NUM_INPUT_FRAMES" ]; then
     exit 0
 else
     mkdir -p "${RESULT_MOVOBJ_DIR}"
-    MOVOBJ_OPTS="--config ${PARAM_FILE} \
-    --input_dir \"${INPUT_DIR}\" \
-    --flow_result_dir \"${RESULT_FLOW_DIR}\" \
-    --segment_result_dir \"${RESULT_SEG_DIR}\" \
-    --result_dir \"${RESULT_MOVOBJ_DIR}\"" # overwrite result dirs based on input data.
     if [ $LOG_LEVEL -ge 5 ]; then
        echo "[NOTE] Please press F5 to start debugging!"
-       python -Xfrozen_modules=off -m debugpy --listen 5678 --wait-for-client ${ROOT_DIR}/reconstruct4D/extract_moving_objects.py ${MOVOBJ_OPTS}
+       python -Xfrozen_modules=off -m debugpy --listen 5678 --wait-for-client "${ROOT_DIR}/reconstruct4D/extract_moving_objects.py" \
+       --config "${PARAM_FILE}" \
+       --input_dir "${INPUT_DIR}" \
+       --flow_result_dir "${RESULT_FLOW_DIR}" \
+       --segment_result_dir "${RESULT_SEG_DIR}" \
+       --result_dir "${RESULT_MOVOBJ_DIR}"
     else
-       python ${ROOT_DIR}/reconstruct4D/extract_moving_objects.py ${MOVOBJ_OPTS}
+       python "${ROOT_DIR}/reconstruct4D/extract_moving_objects.py" \
+       --config "${PARAM_FILE}" \
+       --input_dir "${INPUT_DIR}" \
+       --flow_result_dir "${RESULT_FLOW_DIR}" \
+       --segment_result_dir "${RESULT_SEG_DIR}" \
+       --result_dir "${RESULT_MOVOBJ_DIR}"
     fi
 fi
 

--- a/script/run_foels.sh
+++ b/script/run_foels.sh
@@ -211,34 +211,14 @@ else
                      --vis_dir "${OUTPUT_ABS}"
                      cd "${ROOT_DIR}"
 
-                     # Check if input images start from 00000 or 00001 to determine renaming strategy
+                     # Check if input images start from 00000 or 00001 to determine if renaming is needed
+                     # MemFlow's inference_wrapper.py now correctly detects the starting index
                      if [ -f "${INPUT_ABS}/00000.jpg" ] || [ -f "${INPUT_ABS}/00000.png" ]; then
-                         echo "[INFO] Input images start from 00000, keeping 0-indexed flow files"
-                         # No renaming needed for DAVIS2016 and similar datasets
+                         echo "[INFO] Input images start from 00000, MemFlow generated 0-indexed flow files correctly"
                      elif [ -f "${INPUT_ABS}/000000.jpg" ] || [ -f "${INPUT_ABS}/000000.png" ]; then
-                         echo "[INFO] Input images start from 000000 (6-digit), keeping 0-indexed flow files"
-                         # No renaming needed
+                         echo "[INFO] Input images start from 000000, MemFlow generated 0-indexed flow files correctly"
                      else
-                         # Detect number of digits from first flow file
-                         FIRST_FLOW=$(ls "${OUTPUT_ABS}"/0*_pred.flo 2>/dev/null | head -1)
-                         if [ -n "$FIRST_FLOW" ]; then
-                             # Get the filename without path and extension
-                             BASE_NAME=$(basename "$FIRST_FLOW" | sed 's/_pred.flo$//')
-                             NUM_DIGITS=${#BASE_NAME}
-
-                             # Rename flow files from 0-indexed to 1-indexed for compatibility
-                             echo "[INFO] Renaming flow files for 1-indexed compatibility (${NUM_DIGITS} digits)..."
-                             for file in "${OUTPUT_ABS}"/0*_pred.flo; do
-                                 if [ -f "$file" ]; then
-                                     # Extract the number
-                                     num=$(basename "$file" | sed 's/_pred.flo$//')
-                                     # Remove leading zeros and increment (handle "00000" case with :-0)
-                                     newnum=$(printf "%0${NUM_DIGITS}d" $(( ${num##0*:-0} + 1 )))
-                                     newname="${OUTPUT_ABS}/${newnum}_pred.flo"
-                                     mv "$file" "$newname"
-                                 fi
-                             done
-                         fi
+                         echo "[INFO] Input images start from 00001 or higher, MemFlow generated correctly indexed flow files"
                      fi
 
                      # Reactivate main environment


### PR DESCRIPTION
  Title:
  Hotfix: Fix shell escaping and MemFlow integration issues

  Description:
  ## Summary
  This hotfix addresses critical issues with shell script execution and
  MemFlow integration that were causing pipeline failures.

  ## Issues Fixed

  ### 1. Shell Script Quote Escaping (9d4c75d)
  - Fixed `FileNotFoundError: [Errno 2] No such file or directory:
  '"/path/to/dir"'`
  - Removed problematic `MOVOBJ_OPTS` variable that was passing literal
  quotes to Python
  - Now passes arguments directly with proper quoting

  ### 2. MemFlow Integration (f5f7651)
  - Fixed flow file numbering to correctly handle both 0-indexed and
  1-indexed datasets
  - MemFlow now detects input image indexing automatically:
    - 0-indexed (DAVIS): Generates 00000_pred.flo, 00001_pred.flo, etc.
    - 1-indexed (standard): Generates 00001_pred.flo, 00002_pred.flo,
  etc.
  - Removed incorrect renaming logic that was breaking 1-indexed datasets
  - Updated memflow submodule with proper flow file generation

  ## Testing
  - ✅ Tested with 1-indexed sample data: Works correctly
  - ✅ Tested with 0-indexed DAVIS-like data: Works correctly
  - ✅ Full pipeline completes successfully with both unimatch and
  memflow

  ## Impact
  These fixes ensure the FOELS pipeline works correctly with:
  - Paths containing spaces
  - Both DAVIS (0-indexed) and standard (1-indexed) datasets
  - MemFlow as the default optical flow method